### PR TITLE
Add maxlength constraint to slug configuration

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -11,7 +11,7 @@ slug:
   encoding: unicode
   lowercase: true
   timezone: local
-  maxlength: 50
+  maxlength: 60
 
 collections:
   - name: post

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -11,6 +11,7 @@ slug:
   encoding: unicode
   lowercase: true
   timezone: local
+  maxlength: 50
 
 collections:
   - name: post


### PR DESCRIPTION
## Summary
Added a maximum length constraint to the slug configuration in the Netlify CMS admin settings.

## Changes
- Added `maxlength: 60` to the slug configuration in `static/admin/config.yml`

## Details
This change limits slug generation to a maximum of 60 characters, ensuring that auto-generated slugs don't exceed this length constraint. This helps maintain consistency with URL length best practices and prevents excessively long slugs in the content management system.

https://claude.ai/code/session_01VEBvymcYRArENunGJwLrpc