### PR TITLE
Prevent infinite image optimization with minAbsChange threshold

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -39,6 +39,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           compressOnly: ${{ github.event_name != 'pull_request' }}
           minPctChange: 19
+          minAbsChange: 1024
       - name: Create New Pull Request If Needed
         if: |
           github.event_name != 'pull_request' &&


### PR DESCRIPTION
Adds minAbsChange: 1024 so optimizations are only committed when both
the byte reduction is >= 1 KB AND the percentage reduction is >= 19%.
This uses the fix from calibreapp/image-actions#432, merged 2026-05-18.

https://claude.ai/code/session_01VqJpzRjRCaNbSgPpTKxYyv